### PR TITLE
feat/Make profile photo circular in cards of contributors

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "liveServer.settings.port": 5502
+}

--- a/CSS/index.css
+++ b/CSS/index.css
@@ -75,6 +75,12 @@
         display: none;
     }
 }
+/*To make the card profile circular*/
+
+.card .img-sec img {
+    border-radius: 50%;
+}
+
 
 
 /* Body Section */


### PR DESCRIPTION
I have modified the Page by making the profile photo circular in cards of contributors which will enhance the look and making it look more presentable.
#10 Make profile photo circular in cards of contributors

<img width="890" alt="changed-page1" src="https://github.com/hackbysarthak03/Hacktoberfest2023/assets/124285123/34a4df0f-c916-4832-b294-a5b54f89e866">
